### PR TITLE
Fix hide animation

### DIFF
--- a/freqselector.js
+++ b/freqselector.js
@@ -75,13 +75,13 @@
       .off('click.dismiss.freqselector');
 
     if($.support.transition) {
-      this.$element.css("display", "none");
       this.$element.animate({
       opacity: 0.0,
       height: "0px"
     }, "fast", function() {
+      this.$element.css("display", "none");
       // Move it?
-    });
+    }.bind(this));
     } else {
       this.hideFreqselector();
     }


### PR DESCRIPTION
Currently the freqselector animates smoothly when showing it, but simply disappears when you hide it.

Moving the `css({"display": "none"})` call to the callback for when the animation is finished fixes this.

See https://github.com/twostairs/paperwork/pull/287